### PR TITLE
revert(docs): restore purple primary (CTA revert)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,8 +3,8 @@
   "theme": "mint",
   "name": "Ledgerize API",
   "colors": {
-    "primary": "#FF9AEC",
-    "light": "#B57EFC",
+    "primary": "#B57EFC",
+    "light": "#FF9AEC",
     "dark": "#00FFDD"
   },
   "favicon": "/favicon.svg",


### PR DESCRIPTION
Summary

Revert the CTA color to the previous palette.

Changes

- colors.primary: #B57EFC
- colors.light:   #FF9AEC
- colors.dark:    #00FFDD

Closes

- #4