### PR TITLE
feat(docs): black navbar CTA button

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5,7 +5,7 @@
   "colors": {
     "primary": "#B57EFC",
     "light": "#FF9AEC",
-    "dark": "#00FFDD"
+    "dark": "#000000"
   },
   "favicon": "/favicon.svg",
   "navigation": {


### PR DESCRIPTION
Summary

Set colors.dark to black so the Get started button renders black while keeping other accents intact.

Changes

- primary: #B57EFC (unchanged)
- light:   #FF9AEC (unchanged)
- dark:    #000000 (new)

Closes

- #6