### PR TITLE
feat(docs): pink subheadings in light and dark modes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,7 +3,7 @@
   "theme": "mint",
   "name": "Ledgerize API",
   "colors": {
-    "primary": "#B57EFC",
+    "primary": "#FF9AEC",
     "light": "#FF9AEC",
     "dark": "#000000"
   },


### PR DESCRIPTION
Summary

Align subheading/accent color to pink in both light and dark modes.

Changes

- colors.primary: #FF9AEC (light mode accents/subheadings)
- colors.light:   #FF9AEC (dark mode accents/subheadings)
- colors.dark:    #000000 (CTA remains black)

Verification

- Subheadings and accent UI render pink regardless of mode.
- CTA button remains black.

Closes

- #9