### PR TITLE
fix(docs): remove duplicate H1 titles

### DIFF
--- a/code-examples.mdx
+++ b/code-examples.mdx
@@ -2,8 +2,6 @@
 title: Code Examples
 ---
 
-# Code Examples
-
 ## Node.js (fetch + FormData)
 
 ```ts
@@ -64,4 +62,3 @@ curl -s -H "X-Api-Key: $LEDGERIZE_API_KEY" https://ledgerize.ai/api/v1/jobs/<job
 # Result
 curl -s -H "X-Api-Key: $LEDGERIZE_API_KEY" https://ledgerize.ai/api/v1/jobs/<jobId>/result
 ```
-

--- a/resources/postman.mdx
+++ b/resources/postman.mdx
@@ -2,11 +2,8 @@
 title: Postman
 ---
 
-# Postman
-
 Download the Postman collection:
 
 https://ledgerize.ai/postman/ledgerize.postman_collection.json
 
 Import it to Postman and set `BASE_URL` and `API_KEY` variables.
-


### PR DESCRIPTION
Summary

Pages with frontmatter `title:` were also starting with `# ...` H1s, causing duplicate titles.

Changes

- code-examples.mdx: remove `# Code Examples`
- resources/postman.mdx: remove `# Postman`

Verification

- Pages render a single title (from frontmatter).

Closes

- #13