### PR TITLE
fix(docs): remove duplicate page headings

### DIFF
--- a/authentication.mdx
+++ b/authentication.mdx
@@ -1,4 +1,6 @@
-# Authentication
+---
+title: Authentication
+---
 
 Authenticate every request with your Ledgerize API key via the `X-Api-Key` header.
 
@@ -7,4 +9,3 @@ X-Api-Key: <your-ledgerize-api-key>
 ```
 
 Your key is available in your Ledgerize account under Settings → API Access. Do not expose this key in client-side code.
-

--- a/endpoints/convert.mdx
+++ b/endpoints/convert.mdx
@@ -1,4 +1,6 @@
-# Convert
+---
+title: Convert
+---
 
 `POST /api/v1/convert`
 

--- a/endpoints/jobs.mdx
+++ b/endpoints/jobs.mdx
@@ -1,4 +1,6 @@
-# Jobs
+---
+title: Jobs
+---
 
 ## Status
 `GET /api/v1/jobs/{jobId}`

--- a/endpoints/upload.mdx
+++ b/endpoints/upload.mdx
@@ -1,4 +1,6 @@
-# Upload
+---
+title: Upload
+---
 
 `POST /api/v1/files` (multipart/form-data)
 

--- a/errors.mdx
+++ b/errors.mdx
@@ -1,4 +1,6 @@
-# Errors
+---
+title: Errors
+---
 
 Errors are returned in a normalized JSON envelope:
 
@@ -15,4 +17,3 @@ Common codes:
 - `FILE_REQUIRED` (400): Missing multipart `file` field
 - `PASSWORD_REQUIRED` (400): Missing `password` in body
 - `UPLOAD_FAILED`, `CONVERT_FAILED`, `SET_PASSWORD_FAILED` (5xx): Processing or upstream error
-


### PR DESCRIPTION
Summary

Normalize titles by using frontmatter and removing redundant in-page H1s that caused duplicate headings.

Changes

- authentication.mdx: add `title: Authentication`, remove `# Authentication`
- errors.mdx: add `title: Errors`, remove `# Errors`
- endpoints/upload.mdx: add `title: Upload`, remove `# Upload`
- endpoints/convert.mdx: add `title: Convert`, remove `# Convert`
- endpoints/jobs.mdx: add `title: Jobs`, remove `# Jobs`

Verification

- Each page renders a single title in the header area
- Content below headings remains intact

Closes

- #15