### PR TITLE
chore(docs): rename Postman anchor to Postman Collection

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -38,7 +38,7 @@
       "anchors": [
         { "anchor": "Home", "href": "https://ledgerize.ai", "icon": "house" },
         { "anchor": "Pricing", "href": "https://ledgerize.ai/pricing", "icon": "tag" },
-        { "anchor": "Postman", "href": "https://ledgerize.ai/postman/ledgerize.postman_collection.json", "icon": "file" }
+        { "anchor": "Postman Collection", "href": "https://ledgerize.ai/postman/ledgerize.postman_collection.json", "icon": "file" }
       ]
     }
   },


### PR DESCRIPTION
Summary

Rename the global anchor label from “Postman” to “Postman Collection” for clarity. URL and icon remain the same.

Change

- docs.json: navigation.global.anchors[Postman] → “Postman Collection”

Closes

- #17