### PR TITLE
chore(docs): update Support link to contact-us

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -49,7 +49,7 @@
   "navbar": {
     "links": [
       { "label": "Postman", "href": "https://ledgerize.ai/postman/ledgerize.postman_collection.json" },
-      { "label": "Support", "href": "mailto:support@ledgerize.ai" }
+      { "label": "Support", "href": "https://ledgerize.ai/contact-us" }
     ],
     "primary": { "type": "button", "label": "Get started", "href": "https://ledgerize.ai" }
   },


### PR DESCRIPTION
Summary

Route the navbar Support link to the contact form page.

Change

- docs.json: navbar.links[Support].href → https://ledgerize.ai/contact-us

Closes

- #19