### PR TITLE
Default docs theme to light

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,9 @@
     "light": "#FF9AEC",
     "dark": "#000000"
   },
+  "modeToggle": {
+    "default": "light"
+  },
   "favicon": "/favicon.svg",
   "navigation": {
     "tabs": [


### PR DESCRIPTION
## Summary
- add `modeToggle.default` to `docs.json` so Mintlify defaults to light mode
- keep the theme toggle visible so returning users can still switch

Closes #21