### PR TITLE
Remove template ‘Essentials’ cards from homepage

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -28,38 +28,7 @@ Authenticate with an API key in the `X-Api-Key` header, upload a PDF, start a co
 
 
 
-Everything you need to create world-class documentation.
-
-<Columns cols={2}>
-  <Card
-    title="Write with MDX"
-    icon="pen-fancy"
-    href="/essentials/markdown"
-  >
-    Use MDX to style your docs pages.
-  </Card>
-  <Card
-    title="Code samples"
-    icon="code"
-    href="/essentials/code"
-  >
-    Add sample code to demonstrate how to use your product.
-  </Card>
-  <Card
-    title="Images"
-    icon="image"
-    href="/essentials/images"
-  >
-    Display images and other media.
-  </Card>
-  <Card
-    title="Reusable snippets"
-    icon="recycle"
-    href="/essentials/reusable-snippets"
-  >
-    Write once and reuse across your docs.
-  </Card>
-</Columns>
+<!-- Removed Mintlify template “Essentials” cards to keep the homepage focused on Ledgerize docs. -->
 
 ## Resources
 


### PR DESCRIPTION
Removes the Mintlify starter “Essentials” block from index.mdx to keep the homepage focused on Ledgerize docs.

- No navigation changes; essentials/ folder remains for reference.
- Links for Quick links + Resources are unchanged.

Closes #26.