### PR TITLE
Fix MDX comment syntax on homepage

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -28,7 +28,7 @@ Authenticate with an API key in the `X-Api-Key` header, upload a PDF, start a co
 
 
 
-<!-- Removed Mintlify template “Essentials” cards to keep the homepage focused on Ledgerize docs. -->
+{/* Removed Mintlify template "Essentials" cards to keep the homepage focused on Ledgerize docs. */}
 
 ## Resources
 


### PR DESCRIPTION
Mintlify failed to parse index.mdx due to the HTML comment I added. This PR switches to an MDX expression comment: {/* ... */}.

Once merged, redeploy should succeed and the template cards will be gone.