### PR TITLE
Remove API Reference card from homepage

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -33,6 +33,5 @@ Authenticate with an API key in the `X-Api-Key` header, upload a PDF, start a co
 ## Resources
 
 <Columns cols={2}>
-  <Card title="API Reference" icon="terminal" href="/api-reference">Auto‑generated from OpenAPI.</Card>
   <Card title="Postman" icon="file" href="https://ledgerize.ai/postman/ledgerize.postman_collection.json">Download the collection.</Card>
 </Columns>


### PR DESCRIPTION
Removes the API Reference card from the Resources section of index.mdx.
We still keep the dedicated API Reference tab; this just simplifies the landing page.

Closes #29.