### PR TITLE
Refresh the API docs so the OpenAPI import works

### DIFF
--- a/api-reference/index.mdx
+++ b/api-reference/index.mdx
@@ -18,6 +18,10 @@ Status: Stable (v1)
 Ledgerize exposes a RESTful surface. All endpoints require TLS and are versioned with the `/v1`
 prefix. Non-GET endpoints accept/return JSON unless noted otherwise.
 
+<Info>
+  Job IDs are ephemeral. Treat `/jobs/{jobId}` and `/jobs/{jobId}/result` as short-lived: poll, fetch the result, then store it on your side.
+</Info>
+
 ### Authentication
 
 - **Header**: `X-Api-Key: YOUR_LEDGERIZE_API_KEY`

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -5,10 +5,13 @@ info:
   description: |
     Convert bank statement PDFs into structured data via the Ledgerize API.
     Authentication uses an API key sent in the `X-Api-Key` header.
+externalDocs:
+  description: Download the Postman collection
+  url: https://ledgerize.ai/postman/ledgerize.postman_collection.json
 servers:
   - url: https://ledgerize.ai
     description: Production
-  - url: https://localhost:3000
+  - url: http://localhost:3000
     description: Local (development)
 components:
   securitySchemes:
@@ -16,6 +19,22 @@ components:
       type: apiKey
       in: header
       name: X-Api-Key
+  headers:
+    RateLimitLimit:
+      description: Requests allowed per minute for the provided API key.
+      schema:
+        type: integer
+        minimum: 1
+    RateLimitRemaining:
+      description: Requests remaining in the current window.
+      schema:
+        type: integer
+        minimum: 0
+    RateLimitReset:
+      description: Seconds until the current window resets.
+      schema:
+        type: integer
+        minimum: 0
   schemas:
     Error:
       type: object
@@ -84,7 +103,7 @@ components:
           type: string
         status:
           type: string
-          enum: [pending, processing, completed, failed]
+          enum: [processing, completed, failed]
         progress:
           type: number
           minimum: 0
@@ -139,6 +158,13 @@ paths:
       responses:
         '201':
           description: Created
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
@@ -146,9 +172,28 @@ paths:
               examples:
                 default:
                   $ref: '#/components/schemas/UploadResponse/examples/default'
-        '4XX':
+        '400':
           $ref: '#/components/responses/ErrorResponse'
-        '5XX':
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          description: Rate limited
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          $ref: '#/components/responses/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
           $ref: '#/components/responses/ErrorResponse'
   /api/v1/files/{uuid}/password:
     post:
@@ -173,9 +218,46 @@ paths:
       responses:
         '200':
           description: OK
-        '4XX':
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                  status:
+                    type: string
+                    enum: [ok]
+                required: [uuid, status]
+        '400':
           $ref: '#/components/responses/ErrorResponse'
-        '5XX':
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          description: Rate limited
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          $ref: '#/components/responses/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
           $ref: '#/components/responses/ErrorResponse'
   /api/v1/convert:
     post:
@@ -195,18 +277,46 @@ paths:
       responses:
         '202':
           description: Accepted
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ConvertAccepted'
-        '4XX':
+        '400':
           $ref: '#/components/responses/ErrorResponse'
-        '5XX':
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
+        '429':
+          description: Rate limited
+          headers:
+            X-RateLimit-Limit:
+              $ref: '#/components/headers/RateLimitLimit'
+            X-RateLimit-Remaining:
+              $ref: '#/components/headers/RateLimitRemaining'
+            X-RateLimit-Reset:
+              $ref: '#/components/headers/RateLimitReset'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          $ref: '#/components/responses/ErrorResponse'
+        '503':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
           $ref: '#/components/responses/ErrorResponse'
   /api/v1/jobs/{jobId}:
     get:
       summary: Get job status
       operationId: getJob
+      description: |
+        Jobs are ephemeral. Fetch the result soon after completion.
       parameters:
         - name: jobId
           in: path
@@ -220,12 +330,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/JobStatus'
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '503':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
   /api/v1/jobs/{jobId}/result:
     get:
       summary: Download the conversion result
@@ -254,9 +370,21 @@ paths:
               schema:
                 type: string
                 format: binary
+        '401':
+          $ref: '#/components/responses/ErrorResponse'
         '404':
           description: Not Found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '409':
+          description: Job not completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '503':
+          $ref: '#/components/responses/ErrorResponse'
+        default:
+          $ref: '#/components/responses/ErrorResponse'

--- a/docs.json
+++ b/docs.json
@@ -63,5 +63,5 @@
    ]
   },
   "api": { "openapi": ["api-reference/openapi.yaml"] },
-  "footer": { "socials": { "x": "https://x.com/ledgerize", "github": "https://github.com/wishfulcynic", "linkedin": "https://linkedin.com/company/ledgerize" } }
+  "footer": { "socials": { "x": "https://x.com/ledgerize", "github": "https://github.com/Ledgerize-AI", "linkedin": "https://linkedin.com/company/ledgerize" } }
 }

--- a/endpoints/jobs.mdx
+++ b/endpoints/jobs.mdx
@@ -12,6 +12,11 @@ Returns job status and progress.
 
 Returns the converted data. For `JSON`, the response is JSON; for `CSV`/`XLS`, a file download.
 
+### Notes
+
+- If you request the result before the job completes, you'll get a `409 NOT_READY`.
+- Jobs are ephemeral; fetch results soon after completion (job status and result may not be retained indefinitely).
+
 ```json
 { "normalised": [ { "date": "2025-03-13", "description": "Start balance" } ] }
 ```

--- a/errors.mdx
+++ b/errors.mdx
@@ -13,7 +13,13 @@ Errors are returned in a normalized JSON envelope:
 Common codes:
 
 - `AUTH_INVALID_KEY` (401): Invalid or missing API key
+- `AUTH_NOT_CONFIGURED` (503): API auth is not configured on the server
+- `AUTH_UNAVAILABLE` (503): Temporary issue validating API keys
 - `RATE_LIMITED` (429): Per-key rate limit exceeded
 - `FILE_REQUIRED` (400): Missing multipart `file` field
+- `INVALID_IDS` (400): Missing or empty `ids[]` in a convert request
 - `PASSWORD_REQUIRED` (400): Missing `password` in body
-- `UPLOAD_FAILED`, `CONVERT_FAILED`, `SET_PASSWORD_FAILED` (5xx): Processing or upstream error
+- `NOT_FOUND` (404): Job not found (expired or invalid `jobId`)
+- `NOT_READY` (409): Job exists but is not completed yet
+- `UPLOAD_UNEXPECTED` (502): Upload succeeded upstream, but the response could not be parsed
+- `UPLOAD_FAILED`, `CONVERT_FAILED`, `SET_PASSWORD_FAILED` (502): Processing or upstream error (check `error.details.reason`)

--- a/resources/postman.mdx
+++ b/resources/postman.mdx
@@ -7,3 +7,5 @@ Download the Postman collection:
 https://ledgerize.ai/postman/ledgerize.postman_collection.json
 
 Import it to Postman and set `BASE_URL` and `API_KEY` variables.
+
+The collection will automatically populate `UUID` after upload and `JOB_ID` after starting a conversion.


### PR DESCRIPTION
This aligns the Mintlify docs with the current v1 API behavior.

What changed
- OpenAPI uses real HTTP status codes and documents rate limit headers
- Errors page includes the missing codes we actually return
- Jobs page calls out NOT_READY and that job IDs are ephemeral
- Postman page mentions UUID/JOB_ID auto-fill in the collection